### PR TITLE
add is_regex_valid for ccall

### DIFF
--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -7,6 +7,7 @@
 #include "isocodes.h"
 #include "keycode.h"
 #include <emscripten.h>
+#include <fcitx-config/option.h>
 #include <fcitx-utils/event.h>
 #include <fcitx-utils/i18n.h>
 #include <fcitx-utils/standardpaths.h>
@@ -281,6 +282,10 @@ EMSCRIPTEN_KEEPALIVE void reload(const char *locale, Runtime runtime,
         }
     }
     instance->inputMethodManager().load();
+}
+
+EMSCRIPTEN_KEEPALIVE bool is_regex_valid(const char *pattern) {
+    return fcitx::RegexConstrain().check(pattern);
 }
 }
 } // namespace fcitx


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for regular expression patterns.
  * Invalid patterns are now safely identified without causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->